### PR TITLE
Update serialport to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/RickCraig/node-zeropi#readme",
   "dependencies": {
-    "serialport": "^2.0.0"
+    "serialport": "^3.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This will stop the deprecation warnings in node 6.0.0+, reported by @goophox here: #4
